### PR TITLE
Add Work with me / Services page

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -6,6 +6,7 @@ execute:
 
 website:
   title: "Michal Mottl"
+  site-url: "https://mottl.io"
   navbar:
     right:
       - href: index.qmd

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -10,8 +10,10 @@ website:
     right:
       - href: index.qmd
         text: Home
-      - text: About
-        href: "https://www.linkedin.com/in/mottl/"
+      - href: services.qmd
+        text: Work with me
+      - href: about.qmd
+        text: About
       - posts.qmd
 
 format:

--- a/index.qmd
+++ b/index.qmd
@@ -1,8 +1,5 @@
 ---
-knitr:
-  opts_chunk: 
-    collapse: true
-execute: 
+execute:
   echo: false
 page-layout: full
 ---

--- a/index.qmd
+++ b/index.qmd
@@ -68,12 +68,12 @@ About me, my work and experience.
 ::: {.card-body .d-flex .flex-column}
 <p class="card-text">
 
-Data Viz.
+Work with me on market intelligence, regulatory analytics, and AI-ready data systems.
 
 </p>
 
 ::: {style="margin-top: auto;"}
-<a href="packages.qmd" class="card-link second-color-link heading-font">PROJECTS</a>
+<a href="services.qmd" class="card-link second-color-link heading-font">WORK WITH ME</a>
 :::
 :::
 :::

--- a/services.qmd
+++ b/services.qmd
@@ -1,0 +1,63 @@
+---
+title: "Work with me"
+---
+
+I help organisations operating in **digital and regulated markets** make better strategic decisions by building trusted market intelligence systems.
+
+## Who I work with
+
+- Telecom, fintech, payments, and platform businesses
+- Advisory teams supporting regulated industries
+- Public institutions and market oversight teams
+
+## Services
+
+### 1) Market monitoring system design
+
+I design end-to-end monitoring systems that turn fragmented market data into clear, decision-ready intelligence.
+
+Typical outcomes:
+- Repeatable market KPI framework
+- Automated data collection and pipeline setup
+- Leadership-facing dashboards and reporting
+
+### 2) Regulatory analytics and data trust
+
+I help teams produce robust, transparent analysis that can stand up to regulatory and executive scrutiny.
+
+Typical outcomes:
+- Data quality and validation framework
+- Reproducible analytics workflows
+- Evidence packs for strategic/regulatory decisions
+
+### 3) AI-ready data workflow advisory
+
+I help organisations prepare data workflows for practical AI use without sacrificing reliability.
+
+Typical outcomes:
+- Data readiness assessment
+- Prioritised implementation roadmap
+- Pilot use-cases with measurable impact
+
+## Engagement formats
+
+- Focused diagnostic sprint (1-2 weeks)
+- Project-based delivery (4-12 weeks)
+- Ongoing advisory support
+
+## Why me
+
+I combine:
+- economics and market-structure expertise,
+- regulatory experience,
+- and hands-on data engineering/analytics delivery.
+
+I’ve worked across New Zealand, the EU, and the UK, including roles at the New Zealand Commerce Commission and European Commission.
+
+## Contact
+
+If this is relevant to your team, email me at:
+
+```{=HTML}
+michal<!--.example-->@mottl.io
+```


### PR DESCRIPTION
## Summary
Adds a new **Work with me** page to better position consulting services and improve lead conversion on mottl.io.

## Changes
- Added new page: 
- Updated navbar in :
  - Added 
  - Pointed  to local 
- Updated homepage card in  to point to 

## Why
Supports current goals: contract acquisition, clearer independent-expert positioning, and stronger website conversion path.

## Risks / Notes
- Low risk: content/navigation changes only
- No backend or infrastructure changes