### PR TITLE
Add multi-source intelligence pipelines to services

### DIFF
--- a/services.qmd
+++ b/services.qmd
@@ -20,6 +20,7 @@ Typical outcomes:
 - Repeatable market KPI framework
 - Automated data collection and pipeline setup
 - Leadership-facing dashboards and reporting
+- Multi-source intelligence pipelines (web, newsletters, social, and internal data)
 
 ### 2) Regulatory analytics and data trust
 


### PR DESCRIPTION
## Summary
Adds **multi-source intelligence pipelines** to the services description on mottl.io.

## Change
- Updated  under 'Market monitoring system design' outcomes to include:
  - Multi-source intelligence pipelines (web, newsletters, social, and internal data)

## Why
Reflects Michal's current offering and project direction (including paliwowo discount intelligence).