### PR TITLE
fix: change Polish headline to 'Badanie rynków'

### DIFF
--- a/index.qmd
+++ b/index.qmd
@@ -24,7 +24,7 @@ I help organisations operating in digital and regulated sectors build **trusted 
 :::
 
 ::: {.lang-pl}
-## Wywiad rynkowy i analityka regulacyjna dla złożonych rynków
+## Badanie rynków i analityka regulacyjna dla złożonych rynków
 
 Pomagam organizacjom działającym na rynkach cyfrowych i regulowanych budować **zaufane systemy danych**, które zamieniają rozproszone informacje w jasne, gotowe do decyzji wnioski.
 


### PR DESCRIPTION
## What changed
- Updated the Polish homepage headline wording on the personal website.
- Replaced: "Wywiad rynkowy i analityka regulacyjna dla złożonych rynków"
- With: "Badanie rynków i analityka regulacyjna dla złożonych rynków"

## Why
The new phrasing reads better in Polish and better matches the intended positioning.